### PR TITLE
Remove inline source maps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
   "presets": [
     "es2015"
-  ],
-  "sourceMaps": "inline"
+  ]
 }


### PR DESCRIPTION
No need for this since we're already emitting source map files.